### PR TITLE
chore: add codeowners file to the repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # This group is managed in GitHub and includes Engineering Leadership and a group of individuals that should be responsible for the quality and uniformity of this repo
 *   @DexCare/mobile-sdk-codeowners
-
+*   @DexCare/engineering-leadership

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# This group is managed in GitHub and includes Engineering Leadership and a group of individuals that should be responsible for the quality and uniformity of this repo
+*   @DexCare/mobile-sdk-codeowners
+


### PR DESCRIPTION
This PR adds a `CODEOWNERS` file to the repo so that we can ensure the necessary individuals will be added to PRs. The added `CODEOWNERS` are in the `@DexCare/mobile-sdk-codeowners` group which is a sub-team of the `@DexCare/engineerling-leadership` group.