### PR TITLE
chore: move codeowners to .github folder and teams to a single line

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # This group is managed in GitHub and includes Engineering Leadership and a group of individuals that should be responsible for the quality and uniformity of this repo
-*   @DexCare/mobile-sdk-codeowners
-*   @DexCare/engineering-leadership
+*   @DexCare/mobile-sdk-codeowners @DexCare/engineering-leadership


### PR DESCRIPTION
This PR moves the `CODEOWNERS` file into the `.github` folder to be consistent across DexCare, additionally it moves the teams to a single line

resolves ENG-2548